### PR TITLE
wip(app): Add a working example

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -70,7 +70,9 @@
             "styles": [
               "projects/ngx-element-app/src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [
+              "projects/ngx-element-app/src/js/pure-externals.js"
+            ]
           },
           "configurations": {
             "production": {

--- a/projects/ngx-element-app/src/app/talk/talk.component.html
+++ b/projects/ngx-element-app/src/app/talk/talk.component.html
@@ -4,7 +4,13 @@
 
     <div class="foot">
         <div class="tags">
-            <span class="badge" *ngFor="let tag of talkTags">{{ tag }}</span>
+            <span
+                *ngFor="let tag of talkTags"
+                class="badge"
+                title="Click on me and see that the output is emitted and recognized outside of the component."
+                (click)="invokeClick(tag)">
+                    {{ tag }}
+            </span>
         </div>
         <p class="speaker">{{ speaker }}</p>
     </div>

--- a/projects/ngx-element-app/src/app/talk/talk.component.html
+++ b/projects/ngx-element-app/src/app/talk/talk.component.html
@@ -8,7 +8,7 @@
                 *ngFor="let tag of talkTags"
                 class="badge"
                 title="Click on me and see that the output is emitted and recognized outside of the component."
-                (click)="invokeClick(tag)">
+                (click)="onTagClick(tag)">
                     {{ tag }}
             </span>
         </div>

--- a/projects/ngx-element-app/src/app/talk/talk.component.scss
+++ b/projects/ngx-element-app/src/app/talk/talk.component.scss
@@ -26,8 +26,11 @@
             margin: 5px 0;
         }
 
-        .badge:first-child {
-            margin-left: 0;
+        .badge {
+            cursor: pointer;
+            :first-child {
+                margin-left: 0;
+            }
         }
     }
 }

--- a/projects/ngx-element-app/src/app/talk/talk.component.ts
+++ b/projects/ngx-element-app/src/app/talk/talk.component.ts
@@ -79,7 +79,7 @@ export class TalkComponent implements OnInit {
     this.talkTags = this.tags ? JSON.parse(this.tags) : [];
   }
 
-  invokeClick(tag: string): void {
+  onTagClick(tag: string): void {
     this.tagClick.emit(tag);
   }
 }

--- a/projects/ngx-element-app/src/app/talk/talk.component.ts
+++ b/projects/ngx-element-app/src/app/talk/talk.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, EventEmitter, OnInit, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'app-talk',
@@ -11,11 +11,20 @@ export class TalkComponent implements OnInit {
   @Input() speaker: string;
   @Input() tags: string;
 
+  /*
+  tslint:disable:no-output-rename
+  */
+  @Output('custom-click') customClick = new EventEmitter<string>();
+
   talkTags: string[];
 
   constructor() { }
 
   ngOnInit() {
     this.talkTags = this.tags ? JSON.parse(this.tags) : [];
+  }
+
+  invokeClick(tag: string): void {
+    this.customClick.emit(tag);
   }
 }

--- a/projects/ngx-element-app/src/app/talk/talk.component.ts
+++ b/projects/ngx-element-app/src/app/talk/talk.component.ts
@@ -6,25 +6,80 @@ import { Component, EventEmitter, OnInit, Input, Output } from '@angular/core';
   styleUrls: ['./talk.component.scss']
 })
 export class TalkComponent implements OnInit {
-  @Input() title: string;
-  @Input() description: string;
-  @Input() speaker: string;
-  @Input() tags: string;
 
-  /*
-  tslint:disable:no-output-rename
-  */
-  @Output('custom-click') customClick = new EventEmitter<string>();
+  private _isTestMode = 'N';
+  @Input() set isTestMode(value: string) {
+    if (this._isTestMode !== value) {
+      this._isTestMode = value;
+    }
+  }
+  get isTestMode(): string {
+    return this._isTestMode;
+  }
+
+  private _title: string;
+  @Input() set title(value: string) {
+    if (this._title !== value) {
+      this._title = value;
+      if (this.isTestMode === 'Y') {
+        this.tagClick.emit(`{"attrName": "title", "attrValue": "${value}"}`);
+      }
+    }
+  }
+  get title(): string {
+    return this._title;
+  }
+
+  private _description: string;
+  @Input() set description(value: string) {
+    if (this._description !== value) {
+      this._description = value;
+      if (this.isTestMode === 'Y') {
+        this.tagClick.emit(`{"attrName": "description", "attrValue": "${value}"}`);
+      }
+    }
+  }
+  get description(): string {
+    return this._description;
+  }
+
+  private _speaker: string;
+  @Input() set speaker(value: string) {
+    if (this._speaker !== value) {
+      this._speaker = value;
+      if (this.isTestMode === 'Y') {
+        this.tagClick.emit(`{"attrName": "speaker", "attrValue": "${value}"}`);
+      }
+    }
+  }
+  get speaker(): string {
+    return this._speaker;
+  }
+
+  private _tags: string;
+  @Input() set tags(value: string) {
+    if (this._tags !== value) {
+      this._tags = value;
+      if (this.isTestMode === 'Y') {
+        this.tagClick.emit(`{"attrName": "tags", "attrValue": ${value}}`);
+      }
+    }
+  }
+  get tags(): string {
+    return this._tags;
+  }
+
+  @Output() tagClick = new EventEmitter<string>();
 
   talkTags: string[];
 
-  constructor() { }
+  constructor() {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.talkTags = this.tags ? JSON.parse(this.tags) : [];
   }
 
   invokeClick(tag: string): void {
-    this.customClick.emit(tag);
+    this.tagClick.emit(tag);
   }
 }

--- a/projects/ngx-element-app/src/index.html
+++ b/projects/ngx-element-app/src/index.html
@@ -19,6 +19,15 @@
         data-speaker="Bruno"
         data-tags='["Angular", "Elements"]'>
       </ngx-element>
+      <div class="clicked-tags">
+        To be able to listen to output events of Angular talk component (clicks on its badges):
+        <button
+          onclick="ngxElementTalk.addComponentListener('talk', 'custom-click', 'clicked-tags-container'); this.disabled=true; this.innerText='Already done ...';">
+            Add the listener via pure JS
+        </button>
+        (see dev console)<br /><br />
+        Clicked badges: <span id="clicked-tags-container"></span>
+      </div>
     </div>
 
     <h1 class="section-title">Sponsors</h1>
@@ -26,7 +35,7 @@
       <ngx-element 
         selector="sponsor"
         data-image="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1a/JetBrains_Logo_2016.svg/368px-JetBrains_Logo_2016.svg.png"
-        data-name="Jetbrains">
+        data-name="JetBrains">
       </ngx-element>
     </div>
   </div>

--- a/projects/ngx-element-app/src/index.html
+++ b/projects/ngx-element-app/src/index.html
@@ -22,7 +22,7 @@
       <div class="clicked-tags">
         To be able to listen to output events of Angular talk component (clicks on its badges):
         <button
-          onclick="ngxElementTalk.addComponentListener('talk', 'custom-click', 'clicked-tags-container'); this.disabled=true; this.innerText='Already done ...';">
+          onclick="ngxElementTalk.addComponentListener('talk', 'tagClick', 'clicked-tags-container'); this.disabled=true; this.innerText='Already done ...';">
             Add the listener via pure JS
         </button>
         (see dev console)<br /><br />

--- a/projects/ngx-element-app/src/js/pure-externals.js
+++ b/projects/ngx-element-app/src/js/pure-externals.js
@@ -1,0 +1,24 @@
+const ngxElementTalk = {};
+
+ngxElementTalk.addComponentListener = (selector, output, containerId) => {
+	/**
+	 * Take the instance of <ngx-element> component with the required selector attribute.
+	 */
+	const targetElement = document.querySelector(`ngx-element[selector="${selector}"]`);
+	/**
+	 * Attach a listener on it using the required name, that has to be used inside of Angular component as output name.
+	 */
+	targetElement.addEventListener(output, event => {
+		const clickedTagsContainer = document.getElementById(containerId);
+		const newSpan = document.createElement('span');
+		newSpan.className='badge';
+		/**
+		 * The event property |detail| contains the emitted value.
+		 */
+		newSpan.innerText = event.detail;
+		clickedTagsContainer.appendChild(newSpan);
+		console.log(`... the component output |${output}| emitted an event:`, event);
+	});
+
+	console.log(`... a listener for |${output}| output on the Angular component with selector |${selector}| has been added!`);
+};

--- a/projects/ngx-element-app/src/styles.scss
+++ b/projects/ngx-element-app/src/styles.scss
@@ -34,3 +34,12 @@ body {
     border-radius: 15px;
     font-size: 11px;
 }
+
+.clicked-tags {
+    margin: 10px 0px 5px 0px;
+    text-align: center;
+    button {
+        background-color: lightblue;
+        cursor: pointer;
+    }
+}

--- a/projects/ngx-element/src/lib/ngx-element.component.spec.ts
+++ b/projects/ngx-element/src/lib/ngx-element.component.spec.ts
@@ -7,6 +7,12 @@ describe('NgxElementComponent', () => {
   let component: NgxElementComponent;
   let fixture: ComponentFixture<NgxElementComponent>;
 
+  const inputsAttrs = {
+    title: 'Angular Elements',
+    description: 'How to write Angular and get Web Components',
+    speaker: 'Bruno'
+  };
+
   const lazyConfig = [
     {
       selector: 'talk',
@@ -29,16 +35,50 @@ describe('NgxElementComponent', () => {
       ]
     })
     .compileComponents();
-  }));
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(NgxElementComponent);
     component = fixture.componentInstance;
     component.selector = 'talk';
     fixture.detectChanges();
-  });
+  }));
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should pass and receive the same "title" attr value', () => {
+    let outputObject: {attrName: string, attrValue: string};
+    const nativeElement = fixture.nativeElement;
+    nativeElement.addEventListener('tagClick', (e: CustomEvent) => {
+      outputObject = JSON.parse(e.detail);
+      expect(outputObject.attrValue).toEqual(inputsAttrs[outputObject.attrName]);
+    });
+    nativeElement.setAttribute('data-is-test-mode', 'Y');
+    nativeElement.setAttribute('data-title', inputsAttrs.title);
+    expect().nothing();
+  });
+
+  it('should pass and receive the same "description" attr value', () => {
+    let outputObject: {attrName: string, attrValue: string};
+    const nativeElement = fixture.nativeElement;
+    nativeElement.addEventListener('tagClick', (e: CustomEvent) => {
+      outputObject = JSON.parse(e.detail);
+      expect(outputObject.attrValue).toEqual(inputsAttrs[outputObject.attrName]);
+    });
+    nativeElement.setAttribute('data-is-test-mode', 'Y');
+    nativeElement.setAttribute('data-description', inputsAttrs.description);
+    expect().nothing();
+  });
+
+  it('should pass and receive the same "speaker" attr value', () => {
+    let outputObject: {attrName: string, attrValue: string};
+    const nativeElement = fixture.nativeElement;
+    nativeElement.addEventListener('tagClick', (e: CustomEvent) => {
+      outputObject = JSON.parse(e.detail);
+      expect(outputObject.attrValue).toEqual(inputsAttrs[outputObject.attrName]);
+    });
+    nativeElement.setAttribute('data-is-test-mode', 'Y');
+    nativeElement.setAttribute('data-speaker', inputsAttrs.speaker);
+    expect().nothing();
   });
 });

--- a/projects/ngx-element/src/lib/ngx-element.component.spec.ts
+++ b/projects/ngx-element/src/lib/ngx-element.component.spec.ts
@@ -46,6 +46,18 @@ describe('NgxElementComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  /**
+   * ATTENTION:
+   * Because of calling <dispatchEvent> to emit <customEvent> and the spec of
+   * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent
+   * that says: Unlike "native" events, which are fired by the DOM and invoke
+   * event handlers asynchronously via the event loop, dispatchEvent() invokes
+   * event handlers synchronously. All applicable event handlers will execute
+   * and return before the code continues on after the call to dispatchEvent()
+   * ..., the line of code <outputObject = JSON.parse(e.detail);> is called
+   * always after all other ones, so the expectation has to be evaluated here.
+   */
+
   it('should pass and receive the same "title" attr value', () => {
     let outputObject: {attrName: string, attrValue: string};
     const nativeElement = fixture.nativeElement;

--- a/projects/ngx-element/src/lib/ngx-element.component.ts
+++ b/projects/ngx-element/src/lib/ngx-element.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   ComponentFactory,
+  ComponentRef,
   OnInit,
   Input,
   Output,
@@ -31,7 +32,7 @@ export class NgxElementComponent implements OnInit, OnDestroy {
   @Input() selector: string;
   @ViewChild('container', {read: ViewContainerRef}) container;
 
-  componentRef;
+  componentRef: ComponentRef<any>;
   componentToLoad: Type<any>;
   componentFactoryResolver: ComponentFactoryResolver;
   injector: Injector;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,6 @@
     ],
     "paths": {
       "ngx-element": [
-        "dist/ngx-element/ngx-element",
         "dist/ngx-element"
       ]
     }

--- a/tslint.json
+++ b/tslint.json
@@ -74,6 +74,12 @@
     "template-banana-in-box": true,
     "template-no-negated-async": true,
     "use-lifecycle-interface": true,
-    "use-pipe-transform-interface": true
+    "use-pipe-transform-interface": true,
+    "variable-name": {
+      "options": [
+        "check-format",
+        "allow-leading-underscore"
+      ]
+    }
   }
 }


### PR DESCRIPTION
UPDATE: I tried once more, and both variants work, so it had to be by something else. What was the reason to have that `"dist/ngx-element/ngx-element"` line at all?

Your problem with the correct running of new functionality was related to the definition of the `ngx-element` path.

When I applied the setting:

```
"paths": {
      "ngx-element": ["dist/ngx-element"]
}
```
instead of
```
"paths": {
      "ngx-element": [
        "dist/ngx-element/ngx-element",	
        "dist/ngx-element"
      ]
}
```
it started to work even in the repository demo app.