### PR TITLE
Adds eg-brs extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ export class TalkModule {
 Just like with the Angular Router, define the map of component selector and lazy module.
 
 ```
-const lazyConfig = [
-  {
-    selector: 'talk',
-    loadChildren: () => import('./talk/talk.module').then(m => m.TalkModule)
-  }
+const lazyConfig = {
+  definitions: [
+    {
+      selector: 'talk',
+      loadChildren: () => import('./talk/talk.module').then(m => m.TalkModule)
+    }
+  ],
+  useCustomElementNames: false
 ];
 
 @NgModule({

--- a/projects/ngx-element/README.md
+++ b/projects/ngx-element/README.md
@@ -42,12 +42,16 @@ export class TalkModule {
 Just like with the Angular Router, define the map of component selector and lazy module.
 
 ```
-const lazyConfig = [
-  {
-    selector: 'talk',
-    loadChildren: () => import('./talk/talk.module').then(m => m.TalkModule)
-  }
+const lazyConfig = {
+  definitions: [
+    {
+      selector: 'talk',
+      loadChildren: () => import('./talk/talk.module').then(m => m.TalkModule)
+    }
+  ],
+  useCustomElementNames: false
 ];
+
 
 @NgModule({
   ...,

--- a/projects/ngx-element/src/lib/ngx-element.component.spec.ts
+++ b/projects/ngx-element/src/lib/ngx-element.component.spec.ts
@@ -1,34 +1,31 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NgxElementComponent } from './ngx-element.component';
-import { LAZY_CMPS_PATH_TOKEN } from './tokens';
+import { createDef, LazyComponentRegistry, LAZY_CMPS_REGISTRY } from './tokens';
 
 describe('NgxElementComponent', () => {
   let component: NgxElementComponent;
   let fixture: ComponentFixture<NgxElementComponent>;
 
-  const lazyConfig = [
-    {
-      selector: 'talk',
-      loadChildren: () => import('../../../ngx-element-app/src/app/talk/talk.module').then(m => m.TalkModule)
-    },
-    {
-      selector: 'sponsor',
-      loadChildren: () => import('../../../ngx-element-app/src/app/sponsor/sponsor.module').then(m => m.SponsorModule)
-    }
-  ];
+  const lazyConfig: LazyComponentRegistry = {
+    definitions: [
+      createDef('talk', () => import('../../../ngx-element-app/src/app/talk/talk.module').then(m => m.TalkModule)),
+      createDef('sponsor', () => import('../../../ngx-element-app/src/app/sponsor/sponsor.module').then(m => m.SponsorModule))
+    ],
+    useCustomElementNames: false
+  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ NgxElementComponent ],
+      declarations: [NgxElementComponent],
       providers: [
         {
-          provide: LAZY_CMPS_PATH_TOKEN,
+          provide: LAZY_CMPS_REGISTRY,
           useValue: lazyConfig
         }
       ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/projects/ngx-element/src/lib/ngx-element.component.ts
+++ b/projects/ngx-element/src/lib/ngx-element.component.ts
@@ -3,7 +3,6 @@ import {
   ComponentFactory,
   OnInit,
   Input,
-  Output,
   Type,
   ViewChild,
   ViewContainerRef,
@@ -12,7 +11,6 @@ import {
   EventEmitter,
   ElementRef,
   Injector,
-  ReflectiveInjector,
   Inject
 } from '@angular/core';
 import {NgxElementService} from './ngx-element.service';

--- a/projects/ngx-element/src/lib/ngx-element.service.spec.ts
+++ b/projects/ngx-element/src/lib/ngx-element.service.spec.ts
@@ -1,26 +1,23 @@
 import { TestBed } from '@angular/core/testing';
 import { NgxElementService } from './ngx-element.service';
-import { LAZY_CMPS_PATH_TOKEN } from './tokens';
+import { createDef, LazyComponentRegistry, LAZY_CMPS_REGISTRY } from './tokens';
 
 describe('NgxElementService', () => {
   let service: NgxElementService;
 
-  const lazyConfig = [
-    {
-      selector: 'talk',
-      loadChildren: () => import('../../../ngx-element-app/src/app/talk/talk.module').then(m => m.TalkModule)
-    },
-    {
-      selector: 'sponsor',
-      loadChildren: () => import('../../../ngx-element-app/src/app/sponsor/sponsor.module').then(m => m.SponsorModule)
-    }
-  ];
+  const lazyConfig: LazyComponentRegistry = {
+    definitions: [
+      createDef('talk', () => import('../../../ngx-element-app/src/app/talk/talk.module').then(m => m.TalkModule)),
+      createDef('sponsor', () => import('../../../ngx-element-app/src/app/sponsor/sponsor.module').then(m => m.SponsorModule))
+    ],
+    useCustomElementNames: false
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         {
-          provide: LAZY_CMPS_PATH_TOKEN,
+          provide: LAZY_CMPS_REGISTRY,
           useValue: lazyConfig
         }
       ]

--- a/projects/ngx-element/src/lib/ngx-element.service.ts
+++ b/projects/ngx-element/src/lib/ngx-element.service.ts
@@ -50,6 +50,10 @@ export class NgxElementService {
     return from(registered);
   }
 
+  /**
+   * Checks whether the selector is registered in the registry.
+   * @param selector
+   */
   isSelectorRegistered(selector: string) {
     let result = false;
     this.registry.definitions.forEach(def => {

--- a/projects/ngx-element/src/lib/ngx-element.service.ts
+++ b/projects/ngx-element/src/lib/ngx-element.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject, NgModuleFactory, Type, Compiler, Injector, ComponentFactoryResolver } from '@angular/core';
-import { LAZY_CMPS_PATH_TOKEN, LazyComponentDef } from './tokens';
+import { LAZY_CMPS_REGISTRY, LazyComponentDef, LazyComponentRegistry } from './tokens';
 import { LazyCmpLoadedEvent } from './lazy-component-loaded-event';
 import { Observable, from } from 'rxjs';
 
@@ -15,15 +15,12 @@ export class NgxElementService {
   componentFactoryResolvers = new Map<Type<any>, ComponentFactoryResolver>();
 
   constructor(
-    @Inject(LAZY_CMPS_PATH_TOKEN)
-    modulePaths: {
-      selector: string
-    }[],
+    @Inject(LAZY_CMPS_REGISTRY) private registry: LazyComponentRegistry,
     private compiler: Compiler,
     private injector: Injector
   ) {
     const ELEMENT_MODULE_PATHS = new Map<string, any>();
-    modulePaths.forEach(route => {
+    registry.definitions.forEach(route => {
       ELEMENT_MODULE_PATHS.set(route.selector, route);
     });
 
@@ -51,6 +48,16 @@ export class NgxElementService {
     // Returns observable that completes when the lazy module has been loaded.
     const registered = this.loadComponent(selector);
     return from(registered);
+  }
+
+  isSelectorRegistered(selector: string) {
+    let result = false;
+    this.registry.definitions.forEach(def => {
+      if (selector === def.selector) {
+        result = true;
+      }
+    });
+    return result;
   }
 
   /**
@@ -93,35 +100,35 @@ export class NgxElementService {
             }
           })
           .then(moduleFactory => {
-              const elementModuleRef = moduleFactory.create(this.injector);
-              let componentClass;
+            const elementModuleRef = moduleFactory.create(this.injector);
+            let componentClass;
 
-              if (typeof elementModuleRef.instance.customElementComponent === 'object') {
-                componentClass = elementModuleRef.instance.customElementComponent[componentSelector];
+            if (typeof elementModuleRef.instance.customElementComponent === 'object') {
+              componentClass = elementModuleRef.instance.customElementComponent[componentSelector];
 
-                if (!componentClass) {
-                  // tslint:disable-next-line: no-string-throw
-                  throw `You specified multiple component elements in module ${elementModuleRef} but there was no match for tag
+              if (!componentClass) {
+                // tslint:disable-next-line: no-string-throw
+                throw `You specified multiple component elements in module ${elementModuleRef} but there was no match for tag
                         ${componentSelector} in ${JSON.stringify(elementModuleRef.instance.customElementComponent)}.
                          Make sure the selector in the module is aligned with the one specified in the lazy module definition.`;
-                }
-              } else {
-                componentClass = elementModuleRef.instance.customElementComponent;
               }
+            } else {
+              componentClass = elementModuleRef.instance.customElementComponent;
+            }
 
-              // Register injector of the lazy module.
-              // This is needed to share the entryComponents between the lazy module and the application
-              const moduleInjector = elementModuleRef.injector;
-              this.receiveContext(componentClass, moduleInjector);
+            // Register injector of the lazy module.
+            // This is needed to share the entryComponents between the lazy module and the application
+            const moduleInjector = elementModuleRef.injector;
+            this.receiveContext(componentClass, moduleInjector);
 
-              this.loadedComponents.set(componentSelector, componentClass);
-              this.elementsLoading.delete(componentSelector);
-              this.componentsToLoad.delete(componentSelector);
+            this.loadedComponents.set(componentSelector, componentClass);
+            this.elementsLoading.delete(componentSelector);
+            this.componentsToLoad.delete(componentSelector);
 
-              resolve({
-                selector: componentSelector,
-                componentClass
-              });
+            resolve({
+              selector: componentSelector,
+              componentClass
+            });
           })
           .catch(err => {
             this.elementsLoading.delete(componentSelector);

--- a/projects/ngx-element/src/lib/tokens.ts
+++ b/projects/ngx-element/src/lib/tokens.ts
@@ -2,9 +2,22 @@ import { InjectionToken } from '@angular/core';
 import { LoadChildrenCallback } from '@angular/router';
 
 /* Injection token to provide the element path modules. */
-export const LAZY_CMPS_PATH_TOKEN = new InjectionToken('ngx-lazy-cmp-registry');
+export const LAZY_CMPS_REGISTRY = new InjectionToken('ngx-lazy-cmp-registry');
 
 export interface LazyComponentDef {
   selector: string;
   loadChildren: LoadChildrenCallback; // prop needs to be named like this
+}
+
+export interface LazyComponentRegistry {
+  /** A list of LazyComponentDef for this registry. */
+  definitions: LazyComponentDef[];
+  /** Whether this uses native custom element tag names or an selector attribute. */
+  useCustomElementNames: boolean;
+  /** If useCustomElementNames is true, then this specifies the REQUIRED prefix for the tag names according to Custom Element specification. */
+  customElementNamePrefix?: string;
+}
+
+export function createDef(selector: string, loadChildren: LoadChildrenCallback): LazyComponentDef {
+  return {selector, loadChildren};
 }


### PR DESCRIPTION
This PR adds support for:

* native custom element tag names (fx. `<app-talk title="My talk"></app-talk>`)
* content projection via ng-content (fx. `<app-talk><span>This is projected</span></app-talk>`)
* less verbose configuration when many components are registered.